### PR TITLE
(RE-5755) Old versions of `id` don't understand -u

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ RM          := rm -rf
 CHMOD       := chmod
 CHOWN       := chown
 BUNDLE      := cert.pem
-USER        := $(shell id -u)
-GROUP       := $(shell id -g)
+USER        := $(shell id root |cut -d '=' -f2|cut -d '(' -f1)
+GROUP       := $(shell id root |cut -d '=' -f3|cut -d '(' -f1)
 PERMISSIONS := 0644
 DESTDIR     := $(shell $(OPENSSL) version -d | $(CUT) -d '"' -f 2)
 


### PR DESCRIPTION
This is breaking Solaris 10 builds if they don't have access
to `/usr/xpg4/bin/id`. Slicing the values out of classic `id` should
be sufficient to fix the broken builds for now.
